### PR TITLE
Improved the ParseHttpMethod to be open-close compliant

### DIFF
--- a/MyWebServer/Http/HttpRequest.cs
+++ b/MyWebServer/Http/HttpRequest.cs
@@ -63,15 +63,18 @@
             };
         }
 
-        private static HttpMethod ParseMethod(string method) 
-            => method.ToUpper() switch
+        private static HttpMethod ParseMethod(string method)
+        {
+            try
             {
-                "GET" => HttpMethod.Get,
-                "POST" => HttpMethod.Post,
-                "PUT" => HttpMethod.Put,
-                "DELETE" => HttpMethod.Delete,
-                _ => throw new InvalidOperationException($"Method '{method}' is not supported."),
-            };
+                return (HttpMethod)Enum.Parse(typeof(HttpMethod), method, true);
+            }
+            catch (Exception)
+            {
+                throw new InvalidOperationException($"Method '{method}' is not supported");
+                //return HttpMethod.Get;
+            }
+        }
 
         private static (string, Dictionary<string, string>) ParseUrl(string url)
         {


### PR DESCRIPTION
Changed ParseMethod in HttpRequest so when you add a new HttpMethod you don't have to worry about adding it to the switch. Also in one of your lectures, you said that we can do when we are given a method that we do not support just to do it GET method I left it to you to decide.
![image](https://user-images.githubusercontent.com/56674380/121809678-65b4a480-cc66-11eb-9d2c-d618e69157b5.png)
Just delete one of these lines