### PR TITLE
Added a check for a password which consists of only whitespaces.

### DIFF
--- a/CarShop/Services/Validator.cs
+++ b/CarShop/Services/Validator.cs
@@ -3,6 +3,7 @@
     using CarShop.Models.Cars;
     using CarShop.Models.Users;
     using System;
+    using System.Linq;
     using System.Collections.Generic;
     using System.Text.RegularExpressions;
 
@@ -27,6 +28,11 @@
             if (model.Password.Length < UserMinPassword || model.Password.Length > DefaultMaxLength)
             {
                 errors.Add($"The provided password is not valid. It must be between {UserMinPassword} and {DefaultMaxLength} characters long.");
+            }
+
+            if (model.Password.All(x => x == ' '))
+            {
+                errors.Add($"The provided password cannot be only whitespaces!");
             }
 
             if (model.Password != model.ConfirmPassword)


### PR DESCRIPTION
I Added a check for a password which consists of only whitespaces in the ValidateUser method.

I used a Linq expression because String.IsNullOrWhiteSpace() will return true if the password input is null which will add an incorect error -> "The provided password cannot be only whitespaces!".